### PR TITLE
Implement category CRUD

### DIFF
--- a/src/core/use_cases/CreateCategoryUseCase.php
+++ b/src/core/use_cases/CreateCategoryUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace src\core\use_cases;
+
+use src\core\entities\Category;
+use src\core\repositories\CategoriesRepositoryInterface;
+use src\core\repositories\requests\CategorySearchRequest;
+
+class CreateCategoryUseCase
+{
+  private CategoriesRepositoryInterface $categoriesRepository;
+
+  public function __construct(CategoriesRepositoryInterface $categoriesRepository)
+  {
+    $this->categoriesRepository = $categoriesRepository;
+  }
+
+  public function execute(string $category): Category
+  {
+    $existing = $this->categoriesRepository->find(new CategorySearchRequest(category: $category));
+    if ($existing) {
+      throw new \Exception('Category with this name already exists');
+    }
+
+    $categoryEntity = new Category(
+      id: null,
+      category: $category
+    );
+
+    $this->categoriesRepository->create($categoryEntity);
+
+    return $categoryEntity;
+  }
+}
+?>

--- a/src/core/use_cases/DeleteCategoryUseCase.php
+++ b/src/core/use_cases/DeleteCategoryUseCase.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace src\core\use_cases;
+
+use src\core\repositories\CategoriesRepositoryInterface;
+
+class DeleteCategoryUseCase
+{
+  private CategoriesRepositoryInterface $categoriesRepository;
+
+  public function __construct(CategoriesRepositoryInterface $categoriesRepository)
+  {
+    $this->categoriesRepository = $categoriesRepository;
+  }
+
+  public function execute(int $id): void
+  {
+    $this->categoriesRepository->delete($id);
+  }
+}
+?>

--- a/src/core/use_cases/FetchCategoryUseCase.php
+++ b/src/core/use_cases/FetchCategoryUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace src\core\use_cases;
+
+use src\core\entities\Category;
+use src\core\repositories\CategoriesRepositoryInterface;
+use src\core\repositories\requests\CategorySearchRequest;
+
+class FetchCategoryUseCase
+{
+  private CategoriesRepositoryInterface $categoriesRepository;
+
+  public function __construct(CategoriesRepositoryInterface $categoriesRepository)
+  {
+    $this->categoriesRepository = $categoriesRepository;
+  }
+
+  public function execute(int $id): ?Category
+  {
+    return $this->categoriesRepository->find(new CategorySearchRequest(id: $id));
+  }
+}
+?>

--- a/src/core/use_cases/ListCategoriesUseCase.php
+++ b/src/core/use_cases/ListCategoriesUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace src\core\use_cases;
+
+use src\core\repositories\CategoriesRepositoryInterface;
+use src\core\repositories\requests\CategorySearchRequest;
+
+class ListCategoriesUseCase
+{
+  private CategoriesRepositoryInterface $categoriesRepository;
+
+  public function __construct(CategoriesRepositoryInterface $categoriesRepository)
+  {
+    $this->categoriesRepository = $categoriesRepository;
+  }
+
+  public function execute(?string $category = null): array
+  {
+    return $this->categoriesRepository->list(new CategorySearchRequest(category: $category));
+  }
+}
+?>

--- a/src/core/use_cases/UpdateCategoryUseCase.php
+++ b/src/core/use_cases/UpdateCategoryUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace src\core\use_cases;
+
+use src\core\repositories\CategoriesRepositoryInterface;
+use src\core\repositories\requests\CategorySearchRequest;
+
+class UpdateCategoryUseCase
+{
+  private CategoriesRepositoryInterface $categoriesRepository;
+
+  public function __construct(CategoriesRepositoryInterface $categoriesRepository)
+  {
+    $this->categoriesRepository = $categoriesRepository;
+  }
+
+  public function execute(int $id, string $category): void
+  {
+    $existing = $this->categoriesRepository->find(new CategorySearchRequest(id: $id));
+    if (!$existing) {
+      throw new \InvalidArgumentException('Category not found');
+    }
+
+    $duplicate = $this->categoriesRepository->find(new CategorySearchRequest(category: $category));
+    if ($duplicate && $duplicate->getId() != $id) {
+      throw new \Exception('Category with this name already exists');
+    }
+
+    $existing->setCategory($category);
+    $this->categoriesRepository->update($existing);
+  }
+}
+?>

--- a/src/infra/container/usecases.php
+++ b/src/infra/container/usecases.php
@@ -5,6 +5,11 @@ use src\core\use_cases\FetchUserUseCase;
 use src\core\use_cases\CreateUserUseCase;
 use src\core\use_cases\UpdateUserUseCase;
 use src\core\use_cases\DeleteUserUseCase;
+use src\core\use_cases\ListCategoriesUseCase;
+use src\core\use_cases\FetchCategoryUseCase;
+use src\core\use_cases\CreateCategoryUseCase;
+use src\core\use_cases\UpdateCategoryUseCase;
+use src\core\use_cases\DeleteCategoryUseCase;
 
 
 return [
@@ -41,6 +46,31 @@ return [
   'deleteUserUseCase' => function ($c) {
     return new DeleteUserUseCase(
       $c->get('usersRepository'),
+    );
+  },
+  'listCategoriesUseCase' => function ($c) {
+    return new ListCategoriesUseCase(
+      $c->get('categoriesRepository')
+    );
+  },
+  'fetchCategoryUseCase' => function ($c) {
+    return new FetchCategoryUseCase(
+      $c->get('categoriesRepository')
+    );
+  },
+  'createCategoryUseCase' => function ($c) {
+    return new CreateCategoryUseCase(
+      $c->get('categoriesRepository')
+    );
+  },
+  'updateCategoryUseCase' => function ($c) {
+    return new UpdateCategoryUseCase(
+      $c->get('categoriesRepository')
+    );
+  },
+  'deleteCategoryUseCase' => function ($c) {
+    return new DeleteCategoryUseCase(
+      $c->get('categoriesRepository')
     );
   }
 ];

--- a/src/infra/database/repositories/MySQLCategoriesRepository.php
+++ b/src/infra/database/repositories/MySQLCategoriesRepository.php
@@ -46,7 +46,7 @@ class MySQLCategoriesRepository implements CategoriesRepositoryInterface
       sprintf('SELECT * FROM %s %s', self::TABLE_NAME, $where),
       $params
     );
-    return array_map([MySQLCategoryMapper::class, 'fromArray'], $rows);
+    return array_map([MySQLCategoryMapper::class, 'toDomain'], $rows);
   }
 
   public function create(Category $category): void

--- a/src/infra/http/controllers/api/CreateCategoryController.php
+++ b/src/infra/http/controllers/api/CreateCategoryController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace src\infra\http\controllers\api;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CreateCategoryController
+{
+  private ContainerInterface $container;
+
+  public function __construct(ContainerInterface $container)
+  {
+    $this->container = $container;
+  }
+
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $data = $request->getParsedBody();
+    $category = $data['category'] ?? null;
+
+    if (!$category) {
+      $response->getBody()->write(json_encode(['error' => 'Todos os campos são obrigatórios.']));
+      return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+    }
+
+    $createCategoryUseCase = $this->container->get('createCategoryUseCase');
+
+    try {
+      $createCategoryUseCase->execute($category);
+      header('Location: /admin/categories');
+      exit;
+    } catch (\Exception $e) {
+      $response->getBody()->write(json_encode(['error' => $e->getMessage()]));
+      return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
+    }
+  }
+}
+?>

--- a/src/infra/http/controllers/api/DeleteCategoryController.php
+++ b/src/infra/http/controllers/api/DeleteCategoryController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace src\infra\http\controllers\api;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteCategoryController
+{
+  private ContainerInterface $container;
+
+  public function __construct(ContainerInterface $container)
+  {
+    $this->container = $container;
+  }
+
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $categoryId = $request->getAttribute('id');
+
+    if (!$categoryId) {
+      $response->getBody()->write(json_encode(['error' => 'Category ID is required.']));
+      return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+    }
+
+    $deleteCategoryUseCase = $this->container->get('deleteCategoryUseCase');
+
+    try {
+      $deleteCategoryUseCase->execute($categoryId);
+      header('Location: /admin/categories');
+      exit;
+    } catch (\Exception $e) {
+      $response->getBody()->write(json_encode(['error' => $e->getMessage()]));
+      return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+    }
+  }
+}
+?>

--- a/src/infra/http/controllers/api/UpdateCategoryController.php
+++ b/src/infra/http/controllers/api/UpdateCategoryController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace src\infra\http\controllers\api;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class UpdateCategoryController
+{
+  private ContainerInterface $container;
+
+  public function __construct(ContainerInterface $container)
+  {
+    $this->container = $container;
+  }
+
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $data = $request->getParsedBody();
+    $id = (int) ($args['id'] ?? 0);
+    $category = $data['category'] ?? null;
+
+    if (!$category) {
+      $response->getBody()->write(json_encode(['error' => 'Todos os campos são obrigatórios.']));
+      return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+    }
+
+    $updateCategoryUseCase = $this->container->get('updateCategoryUseCase');
+
+    try {
+      $updateCategoryUseCase->execute($id, $category);
+      header('Location: /admin/categories/' . $id);
+      exit;
+    } catch (\Exception $e) {
+      $response->getBody()->write(json_encode(['error' => $e->getMessage()]));
+      return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
+    }
+  }
+}
+?>

--- a/src/infra/http/controllers/views/admin/CreateCategoryViewController.php
+++ b/src/infra/http/controllers/views/admin/CreateCategoryViewController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace src\infra\http\controllers\views\admin;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use src\infra\http\controllers\ViewController;
+
+class CreateCategoryViewController extends ViewController
+{
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $html = $this->renderView(
+      'admin/categories-create.html.twig',
+      [
+        'currentPage' => 'categories'
+      ],
+      [
+        'auth' => $this->container->get('authContext'),
+        'adminPages' => $this->container->get('adminPagesContext')
+      ]
+    );
+    $response->getBody()->write($html);
+    return $response->withHeader('Content-Type', 'text/html');
+  }
+}
+?>

--- a/src/infra/http/controllers/views/admin/ListCategoriesViewController.php
+++ b/src/infra/http/controllers/views/admin/ListCategoriesViewController.php
@@ -1,0 +1,30 @@
+<?php
+namespace src\infra\http\controllers\views;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use src\infra\http\controllers\ViewController;
+
+class ListCategoriesViewController extends ViewController
+{
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $listCategoriesUseCase = $this->container->get('listCategoriesUseCase');
+    $categories = $listCategoriesUseCase->execute();
+
+    $html = $this->renderView(
+      'admin/categories.html.twig',
+      [
+        'categories' => $categories,
+        'currentPage' => 'categories'
+      ],
+      [
+        'auth' => $this->container->get('authContext'),
+        'adminPages' => $this->container->get('adminPagesContext')
+      ]
+    );
+    $response->getBody()->write($html);
+    return $response->withHeader('Content-Type', 'text/html');
+  }
+}
+?>

--- a/src/infra/http/controllers/views/admin/UpdateCategoryViewController.php
+++ b/src/infra/http/controllers/views/admin/UpdateCategoryViewController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace src\infra\http\controllers\views\admin;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use src\infra\http\controllers\ViewController;
+
+class UpdateCategoryViewController extends ViewController
+{
+  public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $args = []): ResponseInterface
+  {
+    $id = (int) ($args['id'] ?? 0);
+
+    $fetchCategoryUseCase = $this->container->get('fetchCategoryUseCase');
+    $category = $fetchCategoryUseCase->execute($id);
+
+    if (!$category) {
+      $response->getBody()->write('Category not found');
+      return $response->withStatus(404);
+    }
+
+    $html = $this->renderView(
+      'admin/categories-update.html.twig',
+      [
+        'category' => $category,
+        'currentPage' => 'categories'
+      ],
+      [
+        'auth' => $this->container->get('authContext'),
+        'adminPages' => $this->container->get('adminPagesContext')
+      ]
+    );
+    $response->getBody()->write($html);
+    return $response->withHeader('Content-Type', 'text/html');
+  }
+}
+?>

--- a/src/infra/http/routes/api/admin/index.php
+++ b/src/infra/http/routes/api/admin/index.php
@@ -7,6 +7,9 @@ use src\infra\http\controllers\api\CreateUserController;
 use src\infra\http\controllers\api\LogoutController;
 use src\infra\http\controllers\api\UpdateUserController;
 use src\infra\http\controllers\api\DeleteUserController;
+use src\infra\http\controllers\api\CreateCategoryController;
+use src\infra\http\controllers\api\UpdateCategoryController;
+use src\infra\http\controllers\api\DeleteCategoryController;
 
 use src\infra\http\middlewares\EnsureAuthenticatedMiddleware;
 
@@ -17,5 +20,8 @@ return function (App $app) {
         $group->post('/users/create', CreateUserController::class);
         $group->post('/users/{id}', UpdateUserController::class);
         $group->get('/users/{id}/delete', DeleteUserController::class);
+        $group->post('/categories/create', CreateCategoryController::class);
+        $group->post('/categories/{id}', UpdateCategoryController::class);
+        $group->get('/categories/{id}/delete', DeleteCategoryController::class);
     })->add(new EnsureAuthenticatedMiddleware());
 };

--- a/src/infra/http/routes/views/admin/index.php
+++ b/src/infra/http/routes/views/admin/index.php
@@ -5,11 +5,14 @@ use Slim\Routing\RouteCollectorProxy;
 use src\infra\http\middlewares\EnsureAuthenticatedMiddleware;
 
 use src\infra\http\controllers\views\ListUsersViewController;
+use src\infra\http\controllers\views\ListCategoriesViewController;
 
 use src\infra\http\controllers\views\admin\AuthenticateViewController;
 use src\infra\http\controllers\views\admin\CreateUserViewController;
 use src\infra\http\controllers\views\admin\IndexViewController;
 use src\infra\http\controllers\views\admin\UpdateUserViewController;
+use src\infra\http\controllers\views\admin\CreateCategoryViewController;
+use src\infra\http\controllers\views\admin\UpdateCategoryViewController;
 
 return function (App $app) {
   $app->get('/admin/login', AuthenticateViewController::class);
@@ -22,5 +25,11 @@ return function (App $app) {
     $group->get('/users/create', CreateUserViewController::class);
 
     $group->get('/users/{id}', UpdateUserViewController::class);
+
+    $group->get('/categories', ListCategoriesViewController::class);
+
+    $group->get('/categories/create', CreateCategoryViewController::class);
+
+    $group->get('/categories/{id}', UpdateCategoryViewController::class);
   })->add(new EnsureAuthenticatedMiddleware());
 };

--- a/src/presentation/views/admin/categories-create.html.twig
+++ b/src/presentation/views/admin/categories-create.html.twig
@@ -1,0 +1,45 @@
+{% extends '/admin/base.html.twig' %}
+
+{% block title %}Painel Admin
+{% endblock %}
+
+{% block content %}
+        <div class="content-wrapper">
+                <div class="content-header">
+                        <div class="container-fluid">
+                                <div class="row mb-2">
+                                        <div class="col-sm-6">
+                                                <h1 class="m-0">Cadastrar Categoria</h1>
+                                        </div>
+                                        <div class="col-sm-6">
+                                                {% set breadcrumb_items = [
+              { 'href': '/admin', 'label': 'Home' },
+              { 'href': '/admin/categories', 'label': 'Categorias' },
+              { 'label': 'Cadastrar Categoria' }
+            ] %}
+                                                {% include 'admin/components/_breadcrumb.html.twig' with { items: breadcrumb_items } %}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+                <div class="content">
+                        <div class="container-fluid">
+                                <div class="row">
+                                        <div class="col-lg-12">
+                                                {% set card_body %}
+                                                <form role="form" action="/admin/categories/create" method="post">
+                                                        {% include 'admin/components/_form-group.html.twig' with { id: 'category', label: 'Categoria', name: 'category', placeholder: 'Digite o nome da categoria' } %}
+                                                        <button type="submit" class="btn btn-primary mt-3">Cadastrar</button>
+                                                </form>
+                                                {% endset %}
+                                                {% include 'admin/components/_card.html.twig' with {
+              card_header: 'Nova Categoria',
+              outline: false,
+              card_body: card_body
+            } %}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+{% endblock %}

--- a/src/presentation/views/admin/categories-update.html.twig
+++ b/src/presentation/views/admin/categories-update.html.twig
@@ -1,0 +1,45 @@
+{% extends '/admin/base.html.twig' %}
+
+{% block title %}Painel Admin
+{% endblock %}
+
+{% block content %}
+        <div class="content-wrapper">
+                <div class="content-header">
+                        <div class="container-fluid">
+                                <div class="row mb-2">
+                                        <div class="col-sm-6">
+                                                <h1 class="m-0">Editar Categoria</h1>
+                                        </div>
+                                        <div class="col-sm-6">
+                                                {% set breadcrumb_items = [
+                                                { 'href': '/admin', 'label': 'Home' },
+                                                { 'href': '/admin/categories', 'label': 'Categorias' },
+                                                { 'label': 'Editar Categoria' }
+                                        ] %}
+                                                {% include 'admin/components/_breadcrumb.html.twig' with { items: breadcrumb_items } %}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+                <div class="content">
+                        <div class="container-fluid">
+                                <div class="row">
+                                        <div class="col-lg-12">
+                                                {% set card_body %}
+                                                <form role="form" action="/admin/categories/{{ category.id }}" method="post">
+                                                        {% include 'admin/components/_form-group.html.twig' with { id: 'category', label: 'Categoria', name: 'category', placeholder: 'Digite o nome da categoria', value: category.category } %}
+                                                        <button type="submit" class="btn btn-primary mt-3">Salvar</button>
+                                                </form>
+                                                {% endset %}
+                                                {% include 'admin/components/_card.html.twig' with {
+                                                card_header: 'Editar Categoria',
+                                                outline: false,
+                                                card_body: card_body
+                                        } %}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+{% endblock %}

--- a/src/presentation/views/admin/categories.html.twig
+++ b/src/presentation/views/admin/categories.html.twig
@@ -1,0 +1,66 @@
+{% extends '/admin/base.html.twig' %}
+
+{% block title %}Painel Admin
+{% endblock %}
+
+{% block content %}
+<div class="content-wrapper">
+        <div class="content-header">
+                <div class="container-fluid">
+                        <div class="row mb-2">
+                                <div class="col-sm-6">
+                                        <h1 class="m-0">Lista de Categorias</h1>
+                                </div>
+                                <div class="col-sm-6">
+                                        {% set breadcrumb_items = [
+                                                { 'href': '/admin', 'label': 'Home' },
+                                                { 'href': '/admin/categories', 'label': 'Categorias' }
+                                        ] %}
+                                        {% include 'admin/components/_breadcrumb.html.twig' with { items: breadcrumb_items } %}
+                                </div>
+                        </div>
+                </div>
+        </div>
+        <div class="content">
+                <div class="container-fluid">
+                        <div class="row">
+                                <div class="col-lg-12">
+                                        {% set card_body %}
+                                                <div class="mb-3 col-2 px-0">
+                                                        <a href="/admin/categories/create" class="btn btn-block btn-primary">Cadastrar Categoria</a>
+                                                </div>
+                                                <table id="example2" class="table table-bordered table-hover">
+                                                        <thead>
+                                                                <tr>
+                                                                        <th>Categoria</th>
+                                                                        <th>Ações</th>
+                                                                </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                                {% for category in categories %}
+                                                                        <tr>
+                                                                                <td>{{ category.category }}</td>
+                                                                                <td>
+                                                                                        <a href="/admin/categories/{{ category.id }}" class="btn btn-primary btn-xs">
+                                                                                                <i class="fa fa-edit"></i>
+                                                                                                Editar</a>
+                                                                                        <a href="/admin/categories/{{ category.id }}/delete" onclick="return confirm('Deseja realmente excluir este registro?')" class="btn btn-danger btn-xs">
+                                                                                                <i class="fa fa-trash"></i>
+                                                                                                Excluir</a>
+                                                                                </td>
+                                                                        </tr>
+                                                                {% endfor %}
+                                                        </tbody>
+                                                </table>
+                                        {% endset %}
+                                        {% include 'admin/components/_card.html.twig' with {
+                                                card_header: null,
+                                                outline: false,
+                                                card_body: card_body
+                                        } %}
+                                </div>
+                        </div>
+                </div>
+        </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add use cases and container wiring for categories
- expose category CRUD routes and controllers for admin API and views
- create Twig templates for listing, creating, and updating categories

## Testing
- `php -l src/core/use_cases/ListCategoriesUseCase.php src/core/use_cases/FetchCategoryUseCase.php src/core/use_cases/CreateCategoryUseCase.php src/core/use_cases/UpdateCategoryUseCase.php src/core/use_cases/DeleteCategoryUseCase.php`
- `php -l src/infra/http/controllers/api/CreateCategoryController.php src/infra/http/controllers/api/UpdateCategoryController.php src/infra/http/controllers/api/DeleteCategoryController.php src/infra/http/controllers/views/admin/ListCategoriesViewController.php src/infra/http/controllers/views/admin/CreateCategoryViewController.php src/infra/http/controllers/views/admin/UpdateCategoryViewController.php`
- `php -l src/infra/database/repositories/MySQLCategoriesRepository.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68939998297c83218904e1f9eb907685